### PR TITLE
Add arguments for all.equal to bench::mark()

### DIFF
--- a/R/mark.R
+++ b/R/mark.R
@@ -20,7 +20,9 @@ NULL
 #'   with [all.equal()], if `FALSE` checking is disabled. If `check` is a
 #'   function that function will be called with each pair of results to
 #'   determine consistency.
+#' @param check.attributes,check.names arguments passed on to [all.equal()] if `check = TRUE`
 #' @param env The environment which to evaluate the expressions
+#'
 #' @inherit summary.bench_mark return
 #' @aliases bench_mark
 #' @seealso [press()] to run benchmarks across a grid of parameters.
@@ -34,7 +36,8 @@ NULL
 #'   subset(dat, x > 500))
 #' @export
 mark <- function(..., min_time = .5, iterations = NULL, min_iterations = 1,
-                 max_iterations = 10000, check = TRUE, env = parent.frame()) {
+                 max_iterations = 10000, check = TRUE, env = parent.frame(),
+                 check.attributes = TRUE, check.names = TRUE) {
 
   if (!is.null(iterations)) {
     min_iterations <- iterations
@@ -42,7 +45,9 @@ mark <- function(..., min_time = .5, iterations = NULL, min_iterations = 1,
   }
 
   if (isTRUE(check)) {
-    check_fun <- all.equal
+    check_fun <- function(...) {
+      all.equal(..., check.attributes = check.attributes, check.names = check.names)
+    }
   } else if (is.function(check)) {
     check_fun <- check
     check <- TRUE

--- a/man/mark.Rd
+++ b/man/mark.Rd
@@ -6,7 +6,8 @@
 \title{Benchmark a series of functions}
 \usage{
 mark(..., min_time = 0.5, iterations = NULL, min_iterations = 1,
-  max_iterations = 10000, check = TRUE, env = parent.frame())
+  max_iterations = 10000, check = TRUE, env = parent.frame(),
+  check.attributes = TRUE, check.names = TRUE)
 }
 \arguments{
 \item{...}{Expressions to benchmark, if named the \code{expression} column will
@@ -29,6 +30,8 @@ function that function will be called with each pair of results to
 determine consistency.}
 
 \item{env}{The environment which to evaluate the expressions}
+
+\item{check.attributes, check.names}{arguments passed on to \code{\link[=all.equal]{all.equal()}} if \code{check = TRUE}}
 }
 \value{
 A \link[tibble:tibble]{tibble} with the additional summary columns.


### PR DESCRIPTION
I often find myself comparing two functions that return the same basic result with *slight* differences in attributes. Adding these arguments would allow someone to check that the objects are equivalent without having to use `check = function(...) all.equal(..., check.names = FALSE, check.attributes =FALSE)` or some similar incantation. 

Do you think that would work?