### PR TITLE
Update documentation of bench_mark columns.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1.9000
+RoxygenNote: 7.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   vctrs (@romainfrancois, #64)
 * `mark()` now errors correctly when the expressions deparsed length is
   different.
+* Update documentation of `bench_mark` columns (@jdblischak, #67).
 
 # bench 1.0.4
 

--- a/R/mark.R
+++ b/R/mark.R
@@ -164,21 +164,31 @@ time_cols <- c("min", "median", "total_time")
 #'   runs contain a gc.
 #' @return A [tibble][tibble::tibble] with the additional summary columns.
 #'   The following summary columns are computed
+#'   - `expression` - `bench_expr` The deparsed expression that was evaluated
+#'     (or its name if one was provided).
 #'   - `min` - `bench_time` The minimum execution time.
-#'   - `mean` - `bench_time` The arithmetic mean of execution time
 #'   - `median` - `bench_time` The sample median of execution time.
-#'   - `max` - `bench_time` The maximum execution time.
+#'   - `itr/sec` - `double` The estimated number of executions performed per
+#'   second.
 #'   - `mem_alloc` - `bench_bytes` Total amount of memory allocated by R while
 #'     running the expression. Memory allocated *outside* the R heap, e.g. by
 #'     `malloc()` or `new` directly is *not* tracked, take care to avoid
 #'     misinterpreting the results if running code that may do this.
-#'   - `itr/sec` - `integer` The estimated number of executions performed per second.
+#'   - `gc/sec` - `double` The number of garbage collections per second.
 #'   - `n_itr` - `integer` Total number of iterations after filtering
 #'      garbage collections (if `filter_gc == TRUE`).
-#'   - `n_gc` - `integer` Total number of garbage collections performed over all
+#'   - `n_gc` - `double` Total number of garbage collections performed over all
 #'   iterations. This is a psudo-measure of the pressure on the garbage collector, if
 #'   it varies greatly between to alternatives generally the one with fewer
 #'   collections will cause fewer allocation in real usage.
+#'   - `total_time` - `bench_time` The total time to perform the benchmarks.
+#'   - `result` - `list` A list column of the object(s) returned by the
+#'     evaluated expression(s).
+#'   - `memory` - `list` A list column with results from [Rprofmem()].
+#'   - `time` - `list` A list column of `bench_time` vectors for each evaluated
+#'     expression.
+#'   - `gc` - `list` A list column with tibbles containing the level of
+#'     garbage collection (0-2, columns) for each iteration (rows).
 #' @examples
 #' dat <- data.frame(x = runif(10000, 1, 1000), y=runif(10000, 1, 1000))
 #'

--- a/man/autoplot.bench_mark.Rd
+++ b/man/autoplot.bench_mark.Rd
@@ -5,11 +5,13 @@
 \alias{plot.bench_mark}
 \title{Autoplot method for bench_mark objects}
 \usage{
-autoplot.bench_mark(object, type = c("beeswarm", "jitter", "ridge",
-  "boxplot", "violin"), ...)
+autoplot.bench_mark(
+  object,
+  type = c("beeswarm", "jitter", "ridge", "boxplot", "violin"),
+  ...
+)
 
-\method{plot}{bench_mark}(x, ..., type = c("beeswarm", "jitter", "ridge",
-  "boxplot", "violin"), y)
+\method{plot}{bench_mark}(x, ..., type = c("beeswarm", "jitter", "ridge", "boxplot", "violin"), y)
 }
 \arguments{
 \item{object}{A \code{bench_mark} object.}

--- a/man/knit_print.bench_mark.Rd
+++ b/man/knit_print.bench_mark.Rd
@@ -22,7 +22,7 @@ chunk option 'bench.all_columns = TRUE'.
 }
 \details{
 You can set \code{bench.all_columns = TRUE} to show all columns of the bench mark
-object.\preformatted{```{r bench.all_columns = TRUE}
+object.\preformatted{```\{r bench.all_columns = TRUE\}
 bench::mark(
   subset(mtcars, cyl == 3),
   mtcars[mtcars$cyl == 3, ])

--- a/man/mark.Rd
+++ b/man/mark.Rd
@@ -5,10 +5,19 @@
 \alias{bench_mark}
 \title{Benchmark a series of functions}
 \usage{
-mark(..., min_time = 0.5, iterations = NULL, min_iterations = 1,
-  max_iterations = 10000, check = TRUE, filter_gc = TRUE,
-  relative = FALSE, time_unit = NULL, exprs = NULL,
-  env = parent.frame())
+mark(
+  ...,
+  min_time = 0.5,
+  iterations = NULL,
+  min_iterations = 1,
+  max_iterations = 10000,
+  check = TRUE,
+  filter_gc = TRUE,
+  relative = FALSE,
+  time_unit = NULL,
+  exprs = NULL,
+  env = parent.frame()
+)
 }
 \arguments{
 \item{...}{Expressions to benchmark, if named the \code{expression} column will
@@ -51,21 +60,31 @@ defined in \code{...}.}
 A \link[tibble:tibble]{tibble} with the additional summary columns.
 The following summary columns are computed
 \itemize{
+\item \code{expression} - \code{bench_expr} The deparsed expression that was evaluated
+(or its name if one was provided).
 \item \code{min} - \code{bench_time} The minimum execution time.
-\item \code{mean} - \code{bench_time} The arithmetic mean of execution time
 \item \code{median} - \code{bench_time} The sample median of execution time.
-\item \code{max} - \code{bench_time} The maximum execution time.
+\item \code{itr/sec} - \code{double} The estimated number of executions performed per
+second.
 \item \code{mem_alloc} - \code{bench_bytes} Total amount of memory allocated by R while
 running the expression. Memory allocated \emph{outside} the R heap, e.g. by
 \code{malloc()} or \code{new} directly is \emph{not} tracked, take care to avoid
 misinterpreting the results if running code that may do this.
-\item \code{itr/sec} - \code{integer} The estimated number of executions performed per second.
+\item \code{gc/sec} - \code{double} The number of garbage collections per second.
 \item \code{n_itr} - \code{integer} Total number of iterations after filtering
 garbage collections (if \code{filter_gc == TRUE}).
-\item \code{n_gc} - \code{integer} Total number of garbage collections performed over all
+\item \code{n_gc} - \code{double} Total number of garbage collections performed over all
 iterations. This is a psudo-measure of the pressure on the garbage collector, if
 it varies greatly between to alternatives generally the one with fewer
 collections will cause fewer allocation in real usage.
+\item \code{total_time} - \code{bench_time} The total time to perform the benchmarks.
+\item \code{result} - \code{list} A list column of the object(s) returned by the
+evaluated expression(s).
+\item \code{memory} - \code{list} A list column with results from \code{\link[=Rprofmem]{Rprofmem()}}.
+\item \code{time} - \code{list} A list column of \code{bench_time} vectors for each evaluated
+expression.
+\item \code{gc} - \code{list} A list column with tibbles containing the level of
+garbage collection (0-2, columns) for each iteration (rows).
 }
 }
 \description{

--- a/man/press.Rd
+++ b/man/press.Rd
@@ -21,7 +21,7 @@ The parameters you want to set are given as named arguments and a grid of
 all possible combinations is automatically created.
 
 The code to setup and benchmark is given by one unnamed expression (often
-delimited by \code{\{}).
+delimited by \verb{\\\{}).
 
 If replicates are desired a dummy variable can be used, e.g. \code{rep = 1:5} for
 replicates.

--- a/man/scale_bench_expr.Rd
+++ b/man/scale_bench_expr.Rd
@@ -12,11 +12,17 @@ scale_x_bench_expr(...)
 
 scale_y_bench_expr(...)
 
-scale_colour_bench_expr(palette = scales::hue_pal(...), ...,
-  aesthetics = "colour")
+scale_colour_bench_expr(
+  palette = scales::hue_pal(...),
+  ...,
+  aesthetics = "colour"
+)
 
-scale_color_bench_expr(palette = scales::hue_pal(...), ...,
-  aesthetics = "colour")
+scale_color_bench_expr(
+  palette = scales::hue_pal(...),
+  ...,
+  aesthetics = "colour"
+)
 }
 \description{
 Default scales for the \code{bench_expr} class, these are added to plots using

--- a/man/summary.bench_mark.Rd
+++ b/man/summary.bench_mark.Rd
@@ -4,8 +4,7 @@
 \alias{summary.bench_mark}
 \title{Summarize \link[bench:mark]{bench::mark} results.}
 \usage{
-\method{summary}{bench_mark}(object, filter_gc = TRUE,
-  relative = FALSE, time_unit = NULL, ...)
+\method{summary}{bench_mark}(object, filter_gc = TRUE, relative = FALSE, time_unit = NULL, ...)
 }
 \arguments{
 \item{object}{\link{bench_mark} object to summarize.}
@@ -28,21 +27,31 @@ milliseconds, seconds, hours, minutes, days or weeks respectively.}
 A \link[tibble:tibble]{tibble} with the additional summary columns.
 The following summary columns are computed
 \itemize{
+\item \code{expression} - \code{bench_expr} The deparsed expression that was evaluated
+(or its name if one was provided).
 \item \code{min} - \code{bench_time} The minimum execution time.
-\item \code{mean} - \code{bench_time} The arithmetic mean of execution time
 \item \code{median} - \code{bench_time} The sample median of execution time.
-\item \code{max} - \code{bench_time} The maximum execution time.
+\item \code{itr/sec} - \code{double} The estimated number of executions performed per
+second.
 \item \code{mem_alloc} - \code{bench_bytes} Total amount of memory allocated by R while
 running the expression. Memory allocated \emph{outside} the R heap, e.g. by
 \code{malloc()} or \code{new} directly is \emph{not} tracked, take care to avoid
 misinterpreting the results if running code that may do this.
-\item \code{itr/sec} - \code{integer} The estimated number of executions performed per second.
+\item \code{gc/sec} - \code{double} The number of garbage collections per second.
 \item \code{n_itr} - \code{integer} Total number of iterations after filtering
 garbage collections (if \code{filter_gc == TRUE}).
-\item \code{n_gc} - \code{integer} Total number of garbage collections performed over all
+\item \code{n_gc} - \code{double} Total number of garbage collections performed over all
 iterations. This is a psudo-measure of the pressure on the garbage collector, if
 it varies greatly between to alternatives generally the one with fewer
 collections will cause fewer allocation in real usage.
+\item \code{total_time} - \code{bench_time} The total time to perform the benchmarks.
+\item \code{result} - \code{list} A list column of the object(s) returned by the
+evaluated expression(s).
+\item \code{memory} - \code{list} A list column with results from \code{\link[=Rprofmem]{Rprofmem()}}.
+\item \code{time} - \code{list} A list column of \code{bench_time} vectors for each evaluated
+expression.
+\item \code{gc} - \code{list} A list column with tibbles containing the level of
+garbage collection (0-2, columns) for each iteration (rows).
 }
 }
 \description{


### PR DESCRIPTION
I noticed that the documentation of the `bench_mark` object returned by `mark()` was outdated. I made the following updates:

1. Removed `mean` and `max` #37
1. Added new columns
1. Changed `itr/sec` and `n_gc` from `integer` to `double`

I also rebuilt the documentation with roxygen2 7.0.0 (I would have used the same version of roxygen2, but there is no [tag](https://github.com/r-lib/roxygen2/tags) for version 6.1.1.9000).