### PR TITLE
Stop plotting a beeswarm graph if suggested package is not found.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `mark()` now errors correctly when the expressions deparsed length is
   different.
 * Update documentation of `bench_mark` columns (@jdblischak, #67).
+* `autoplot.bench_mark()` provides a more informative error if the `ggbeeswarm` package is not installed (@coatless, #69).
 
 # bench 1.0.4
 

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -52,7 +52,9 @@ autoplot.bench_mark <- function(object,
     stop("`ggplot2` and `tidyr` must be installed to use `autoplot`.", call. = FALSE)
   }
   
-  if (!requireNamespace("ggbeeswarm")) {
+  type <- match.arg(type)
+
+  if (type == "beeswarm" && !requireNamespace("ggbeeswarm", quietly = TRUE)) {
     stop("`ggbeeswarm` must be installed to use `type=\"beeswarm\"` option.", call. = FALSE)
   }
 
@@ -66,7 +68,6 @@ autoplot.bench_mark <- function(object,
   }
   p <- ggplot2::ggplot(res)
 
-  type <- match.arg(type)
 
   switch(type,
     beeswarm = p <- p +

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -51,6 +51,10 @@ autoplot.bench_mark <- function(object,
   if (!(requireNamespace("ggplot2") && requireNamespace("tidyr"))) {
     stop("`ggplot2` and `tidyr` must be installed to use `autoplot`.", call. = FALSE)
   }
+  
+  if (!requireNamespace("ggbeeswarm")) {
+    stop("`ggbeeswarm` must be installed to use `type=\"beeswarm\"` option.", call. = FALSE)
+  }
 
   # Just convert everything to a character first
   object$expression <- as.character(object$expression)

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -55,7 +55,7 @@ autoplot.bench_mark <- function(object,
   type <- match.arg(type)
 
   if (type == "beeswarm" && !requireNamespace("ggbeeswarm", quietly = TRUE)) {
-    stop("`ggbeeswarm` must be installed to use `type=\"beeswarm\"` option.", call. = FALSE)
+    stop("`ggbeeswarm` must be installed to use `type = \"beeswarm\"` option.", call. = FALSE)
   }
 
   # Just convert everything to a character first


### PR DESCRIPTION
Adds logic for detecting if `ggbeeswarm` is not installed.

```r
res_bench = bench::mark(
    func = {
        sum(1:10)
    },
    val = {
        sum(1:10)
    },
    min_time = 60,
    max_iterations = 20
)
plot(res_bench)
Loading required namespace: tidyr
Error in loadNamespace(name) : there is no package called 'ggbeeswarm'
```

Goes to: 

```r
Error: `ggbeeswarm` must be installed to use `type="beeswarm"` option.
```