### PR TITLE
Added 'tolerance' argument for check

### DIFF
--- a/R/mark.R
+++ b/R/mark.R
@@ -26,6 +26,7 @@ NULL
 #'   profiling), track memory allocations using. If `FALSE` disable memory
 #'   tracking.
 #' @param env The environment which to evaluate the expressions
+#' @param tolerance Differences smaller than tolerance are not reported by `check`. The default value is close to 1.5e-8.
 #' @inheritParams summary.bench_mark
 #' @inherit summary.bench_mark return
 #' @aliases bench_mark
@@ -41,7 +42,7 @@ NULL
 #' @export
 mark <- function(..., min_time = .5, iterations = NULL, min_iterations = 1,
                  max_iterations = 10000, check = TRUE, memory = capabilities("profmem"), filter_gc = TRUE,
-                 relative = FALSE, time_unit = NULL, exprs = NULL, env = parent.frame()) {
+                 relative = FALSE, time_unit = NULL, exprs = NULL, env = parent.frame(), tolerance = sqrt(.Machine$double.eps)) {
 
   if (!is.null(iterations)) {
     min_iterations <- iterations
@@ -49,7 +50,7 @@ mark <- function(..., min_time = .5, iterations = NULL, min_iterations = 1,
   }
 
   if (isTRUE(check)) {
-    check_fun <- all.equal
+    check_fun <- function(target, current, ...) all.equal(target, current, ..., tolerance = tolerance)
   } else if (is.function(check)) {
     check_fun <- check
     check <- TRUE


### PR DESCRIPTION
Hi,
I added an argument to the `mark` function to directly define the tolerance used by `all.equal` when checking equality of the expressions being benchmarked. 
I know you can override the default call to `all.equal`, I just thought it was more convenient to have a specific argument to do so.
Here's a silly example:

``` r
library(bench)

f1 <- function() qnorm(0.975)
f2 <- function() 1.95

bench::mark(f1(), f2())
#> Error: Each result must equal the first result:
#> `f1()` does not equal `f2()`
bench::mark(f1(), f2(), tolerance = 0.1)
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 f1()          980ns   1.43µs   565517.   635.2KB     56.6
#> 2 f2()          144ns    200ns  3357833.    24.9KB      0
```

<sup>Created on 2020-06-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>  