### PR TITLE
Slice vectorized `description` along with expressions

### DIFF
--- a/R/expression.R
+++ b/R/expression.R
@@ -29,13 +29,20 @@ type_sum.bench_expr <- function(x) {
 
 #' @export
 `[.bench_expr` <- function(x, i, ...) {
-  new_x <- NextMethod("[")
-  new_bench_expr(new_x)
+  vctrs::vec_slice(x, i)
 }
 
 # @export
 vec_proxy.bench_expr <- function(x, ...) {
-  vctrs::vec_data(unclass(x))
+  desc <- attr(x, "description")
+  attributes(x) <- NULL
+  out <- list(x = x, desc = desc)
+  vctrs::new_data_frame(out, n = length(x))
+}
+
+# @export
+vec_restore.bench_expr <- function(x, to, ...) {
+  new_bench_expr(x$x, x$desc)
 }
 
 pillar_shaft.bench_expr <- function(x, ...) {

--- a/R/expression.R
+++ b/R/expression.R
@@ -29,7 +29,8 @@ type_sum.bench_expr <- function(x) {
 
 #' @export
 `[.bench_expr` <- function(x, i, ...) {
-  vctrs::vec_slice(x, i)
+  new_x <- NextMethod("[")
+  new_bench_expr(new_x)
 }
 
 # @export

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -20,6 +20,7 @@
   register_s3_method("knitr", "knit_print", "bench_mark")
 
   register_s3_method("vctrs", "vec_proxy", "bench_expr")
+  register_s3_method("vctrs", "vec_restore", "bench_expr")
 }
 
 register_s3_method <- function(pkg, generic, class, fun = NULL) {

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -5,3 +5,13 @@ test_that("`description` is sliced along with expressions", {
   expect_identical(attr(x[2], "description"), "b")
   expect_identical(attr(x[c(2, 2, 1)], "description"), c("b", "b", "a"))
 })
+
+test_that("`vec_slice()` slices `description` attribute", {
+  skip_if_not_installed("vctrs")
+
+  x <- as.list(expression(x + y, z + b))
+  x <- new_bench_expr(x, c("a", "b"))
+
+  expect_identical(attr(vctrs::vec_slice(x, 2), "description"), "b")
+  expect_identical(attr(vctrs::vec_slice(x, c(2, 2, 1)), "description"), c("b", "b", "a"))
+})

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -1,0 +1,7 @@
+test_that("`description` is sliced along with expressions", {
+  x <- as.list(expression(x + y, z + b))
+  x <- new_bench_expr(x, c("a", "b"))
+
+  expect_identical(attr(x[2], "description"), "b")
+  expect_identical(attr(x[c(2, 2, 1)], "description"), c("b", "b", "a"))
+})


### PR DESCRIPTION
Closes #85 

Tweaks `vec_proxy()` for bench_expr to return a two column data frame containing the expressions and the vectorized `description` attribute. This way it gets sliced by `vec_slice()`. 

Added a `vec_restore()` method for bench_expr to go from the two column data frame form back to a bench_expr

`[.bench_expr` takes a different code path than `vec_slice()` does for slicing bench_expr objects, so I've added tests for both.