### PR TITLE
adding as.character

### DIFF
--- a/R/continuous_benchmarking.R
+++ b/R/continuous_benchmarking.R
@@ -215,7 +215,7 @@ cb_read <- function(path = ".", additional_columns = NULL) {
   x$benchmarks <- lapply(x$benchmarks, cb_read_benchmark)
 
   # Split the parents into character list-cols
-  x$parent_hashes <- strsplit(x$parent_hashes, " ")
+  x$parent_hashes <- strsplit(as.character(x$parent_hashes), " ")
 
   x$ref_names <- parse_ref_names(x$ref_names)
 


### PR DESCRIPTION
Fixes #107 
`str_split()` required that `x$parent_hashes` was (hard) coerced to `character`.

This change solves this issue.

Best regards!