### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/nanotime.c
+++ b/src/nanotime.c
@@ -2,7 +2,7 @@
 
 #ifdef __WIN32
 #include <windows.h>
-#elif defined(__MACH__)
+#elif defined(__MACH__) && defined (__APPLE__)
 #include <mach/mach_time.h>
 #include <time.h>
 #include <sys/time.h>
@@ -31,7 +31,7 @@ long double real_time() {
   }
   return (long double) count.QuadPart / frequency.QuadPart;
 }
-#elif defined(__MACH__)
+#elif defined(__MACH__) && defined(__APPLE__)
 long double real_time() {
 
   // https://developer.apple.com/library/content/qa/qa1398/_index.html


### PR DESCRIPTION
Hurd also uses Mach.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```