### PR TITLE
Fix `-Wstrict-prototypes` warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bench (development version)
 
+* Fixed `-Wstrict-prototypes` warnings, as requested by CRAN (#124).
+
 * bench no longer Suggests mockery.
 
 # bench 1.1.2

--- a/src/load.c
+++ b/src/load.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #endif
 
-SEXP bench_load_average_() {
+SEXP bench_load_average_(void) {
 
   SEXP out = PROTECT(Rf_allocVector(REALSXP, 3));
   REAL(out)[0] = NA_REAL;

--- a/src/mark.c
+++ b/src/mark.c
@@ -72,7 +72,7 @@ SEXP system_time_(SEXP expr, SEXP env) {
   return out;
 }
 
-SEXP hires_time_() {
+SEXP hires_time_(void) {
   double time = real_time();
   SEXP out = PROTECT(Rf_allocVector(REALSXP, 1));
   REAL(out)[0] = time;
@@ -115,8 +115,8 @@ SEXP parse_gc_(SEXP x) {
   return out;
 }
 
-extern SEXP bench_process_memory_();
-extern SEXP bench_load_average_();
+extern SEXP bench_process_memory_(void);
+extern SEXP bench_load_average_(void);
 
 static const R_CallMethodDef CallEntries[] = {
     {"mark_", (DL_FUNC) &mark_, 5},

--- a/src/nanotime.c
+++ b/src/nanotime.c
@@ -16,7 +16,7 @@
 
 
 #if defined(_WIN32) || defined(_WIN64)
-long double real_time() {
+long double real_time(void) {
   // https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx
   static LARGE_INTEGER frequency;
   frequency.QuadPart = 0;
@@ -32,7 +32,7 @@ long double real_time() {
   return (long double) count.QuadPart / frequency.QuadPart;
 }
 #elif defined(__MACH__)
-long double real_time() {
+long double real_time(void) {
 
   // https://developer.apple.com/library/content/qa/qa1398/_index.html
   //static mach_timebase_info_data_t info;
@@ -51,14 +51,14 @@ long double real_time() {
   return (long double)nanos / NSEC_PER_SEC;
 }
 #elif defined(__sun)
-long double real_time() {
+long double real_time(void) {
   hrtime_t time = gethrtime();
   // The man page doesn't mention any error return values
 
   return (long double)time / NSEC_PER_SEC;
 }
 #else
-long double real_time() {
+long double real_time(void) {
   struct timespec ts;
   if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
     Rf_error("clock_gettime(CLOCK_REALTIME, ...) failed");
@@ -68,7 +68,7 @@ long double real_time() {
 }
 #endif
 
-long double process_cpu_time() {
+long double process_cpu_time(void) {
 #if defined(_WIN32) || defined(_WIN64)
   HANDLE proc = GetCurrentProcess();
   FILETIME creation_time;

--- a/src/nanotime.h
+++ b/src/nanotime.h
@@ -3,8 +3,8 @@
 
 #include "Rinternals.h"
 
-long double real_time();
-long double process_cpu_time();
+long double real_time(void);
+long double process_cpu_time(void);
 long double expr_elapsed_time(SEXP expr, SEXP env);
 
 #endif

--- a/src/process_memory.c
+++ b/src/process_memory.c
@@ -76,7 +76,7 @@ int read_proc_file(const char *file, uint64_t *val, char *field, int fieldlen) {
 }
 #endif
 
-SEXP bench_process_memory_() {
+SEXP bench_process_memory_(void) {
 
   SEXP out = PROTECT(Rf_allocVector(REALSXP, 2));
   REAL(out)[0] = NA_REAL;


### PR DESCRIPTION
```
Result: WARN
    Found the following significant warnings:
     load.c:11:25: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     ./nanotime.h:6:22: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     ./nanotime.h:7:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     mark.c:75:17: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     mark.c:118:34: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     mark.c:119:32: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     nanotime.c:61:22: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     nanotime.c:71:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     process_memory.c:79:27: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
```