### PR TITLE
Forward to `pillar::pillar_shaft.character()` for `bench_expr`s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bench (development version)
 
+* Long unnamed `bench_expr` expressions are now truncated correctly when used as
+  columns of a tibble (#94).
+
 * bench now uses testthat 3e (#129).
 
 * Fixed `-Wstrict-prototypes` warnings, as requested by CRAN (#124).

--- a/R/expression.R
+++ b/R/expression.R
@@ -47,7 +47,10 @@ vec_restore.bench_expr <- function(x, to, ...) {
 }
 
 pillar_shaft.bench_expr <- function(x, ...) {
-  pillar::new_pillar_shaft_simple(format.bench_expr(x), align = "left", ...)
+  # We format bench expressions exactly like character vectors. This ensures
+  # they are truncated as needed, which is useful for long unnamed expressions
+  # (#94). This is the same logic as `pillar:::pillar_shaft.factor()`.
+  pillar::pillar_shaft(as.character(x), ...)
 }
 
 scale_type.bench_expr <- function(x) {

--- a/tests/testthat/_snaps/mark.md
+++ b/tests/testthat/_snaps/mark.md
@@ -16,3 +16,13 @@
       ! Each result must equal the first result:
       `if (TRUE) 2` does not equal `if (TRUE) 1 else 3`
 
+# mark: truncates long expressions when printing (#94)
+
+    Code
+      out
+    Output
+      # A tibble: 1 x 2
+        expression            result
+        <bch:expr>            <list>
+      1 aaaaaaaaaaaaaaaaaaaa~ <dbl> 
+

--- a/tests/testthat/test-mark.R
+++ b/tests/testthat/test-mark.R
@@ -126,6 +126,21 @@ describe("mark", {
       2 + 2,
     )
   })
+  it("truncates long expressions when printing (#94)", {
+    local_reproducible_output(width = 30)
+
+    name <- paste0(rep("a", 100), collapse = "")
+    exprs <- list(as.name(name))
+
+    assign(name, 1, envir = environment())
+
+    out <- mark(exprs = exprs)
+
+    # Only snapshot static columns
+    out <- out[c("expression", "result")]
+
+    expect_snapshot(out)
+  })
 })
 
 describe("summary.bench_mark", {


### PR DESCRIPTION
Closes #94 

This ensures we get truncation that matches how it works for character vectors, which is generally pretty aggressive since you can often figure out which expression you are looking at from the first few characters, and it is more important to try and show more columns rather than showing everything contained in very long expressions.

``` r
# CRAN bench
bench::mark(as.character(as.character(as.character(as.character(as.character(letters))))))
#> # A tibble: 1 × 6
#>   expression                                                                   
#>   <bch:expr>                                                                   
#> 1 as.character(as.character(as.character(as.character(as.character(letters)))))
#> # ℹ 5 more variables: min <bch:tm>, median <bch:tm>, `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>

# This PR
bench::mark(as.character(as.character(as.character(as.character(as.character(letters))))))
#> # A tibble: 1 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 as.character(as.character(as.charac… 239ns  323ns  2319718.        0B        0
```

<sup>Created on 2023-05-02 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>