### PR TITLE
Use `os.h` defines in `nanotime.c`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bench (development version)
 
+* Fixed an issue where macOS specific C code paths were accidentally being used
+  on GNU Hurd (#118).
+
 * Long unnamed `bench_expr` expressions are now truncated correctly when used as
   columns of a tibble (#94).
 

--- a/src/os.h
+++ b/src/os.h
@@ -19,4 +19,10 @@
 #define OS_LINUX 0
 #endif
 
+#ifdef __sun
+#define OS_SOLARIS 1
+#else
+#define OS_SOLARIS 0
+#endif
+
 #endif


### PR DESCRIPTION
Closes #120
Closes #118

It seems good to be consistent, since these are already used in all the other files. Also added a few notes about when specific `process_cpu_time()` code paths are triggered based on some git archeology.

This fixes #118 because previously `nanotime.c` was detecting macOS with `__MACH__`, but it seems like that is also defined by GNU Hurd. The more proper way is to just look for `__APPLE__`, which is what `OS_MACOS` already does.