### PR TITLE
Fix configuration of breaks when using recent scales package.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bench (development version)
 
+* Fixed an issue in `bench_time_trans()` and `bench_bytes_trans()` where pretty
+  breaks were not being applied correctly (#140, @plietar, @simonpcouch).
+
 * R >=4.0.0 is now required, which is aligned with tidyverse standards.
 
 * Switched to modern ggplot2 conventions internally (#141, @olivroy).

--- a/R/bytes.R
+++ b/R/bytes.R
@@ -169,16 +169,18 @@ type_sum.bench_bytes <- function(x) {
 bench_bytes_trans <- function(base = 2) {
   if (is.null(base)) {
     return(
-      scales::trans_new("bch:byt", as.numeric, as_bench_bytes,
-        scales::pretty_breaks(), domain = c(1e-100, Inf)
+      scales::trans_new("bch:byt", transform = as.numeric,
+        inverse = as_bench_bytes, breaks = scales::pretty_breaks(),
+        domain = c(1e-100, Inf)
       )
     )
   }
   trans <- function(x) log(as.numeric(x), base)
   inv <- function(x) as_bench_bytes(base ^ as.numeric(x))
 
-  scales::trans_new(paste0("bch:byt-", format(base)), trans, inv,
-    scales::log_breaks(base = base), domain = c(1e-100, Inf))
+  scales::trans_new(paste0("bch:byt-", format(base)), transform = trans,
+    inverse = inv, breaks = scales::log_breaks(base = base),
+    domain = c(1e-100, Inf))
 }
 
 # Lazily registered in `.onLoad()`

--- a/R/bytes.R
+++ b/R/bytes.R
@@ -169,8 +169,11 @@ type_sum.bench_bytes <- function(x) {
 bench_bytes_trans <- function(base = 2) {
   if (is.null(base)) {
     return(
-      scales::trans_new("bch:byt", transform = as.numeric,
-        inverse = as_bench_bytes, breaks = scales::pretty_breaks(),
+      scales::trans_new(
+        name = "bch:byt",
+        transform = as.numeric,
+        inverse = as_bench_bytes,
+        breaks = scales::pretty_breaks(),
         domain = c(1e-100, Inf)
       )
     )
@@ -178,9 +181,13 @@ bench_bytes_trans <- function(base = 2) {
   trans <- function(x) log(as.numeric(x), base)
   inv <- function(x) as_bench_bytes(base ^ as.numeric(x))
 
-  scales::trans_new(paste0("bch:byt-", format(base)), transform = trans,
-    inverse = inv, breaks = scales::log_breaks(base = base),
-    domain = c(1e-100, Inf))
+  scales::trans_new(
+    name = paste0("bch:byt-", format(base)),
+    transform = trans,
+    inverse = inv,
+    breaks = scales::log_breaks(base = base),
+    domain = c(1e-100, Inf)
+  )
 }
 
 # Lazily registered in `.onLoad()`

--- a/R/time.R
+++ b/R/time.R
@@ -209,8 +209,9 @@ type_sum.bench_time <- function(x) {
 bench_time_trans <- function(base = 10) {
   if (is.null(base)) {
     return(
-      scales::trans_new("bch:tm", as.numeric, as_bench_time,
-        scales::pretty_breaks(), domain = c(1e-100, Inf)
+      scales::trans_new("bch:tm", transform = as.numeric,
+        inverse = as_bench_time, breaks = scales::pretty_breaks(),
+        domain = c(1e-100, Inf)
       )
     )
   }
@@ -218,8 +219,9 @@ bench_time_trans <- function(base = 10) {
   trans <- function(x) log(as.numeric(x), base)
   inv <- function(x) as_bench_time(base ^ as.numeric(x))
 
-  scales::trans_new(paste0("bch:tm-", format(base)), trans, inv,
-    scales::log_breaks(base = base), domain = c(1e-100, Inf))
+  scales::trans_new(paste0("bch:tm-", format(base)), transform = trans,
+    inverse = inv, breaks = scales::log_breaks(base = base),
+    domain = c(1e-100, Inf))
 }
 
 # Lazily registered in `.onLoad()`

--- a/R/time.R
+++ b/R/time.R
@@ -209,8 +209,11 @@ type_sum.bench_time <- function(x) {
 bench_time_trans <- function(base = 10) {
   if (is.null(base)) {
     return(
-      scales::trans_new("bch:tm", transform = as.numeric,
-        inverse = as_bench_time, breaks = scales::pretty_breaks(),
+      scales::trans_new(
+        name = "bch:tm",
+        transform = as.numeric,
+        inverse = as_bench_time,
+        breaks = scales::pretty_breaks(),
         domain = c(1e-100, Inf)
       )
     )
@@ -219,9 +222,13 @@ bench_time_trans <- function(base = 10) {
   trans <- function(x) log(as.numeric(x), base)
   inv <- function(x) as_bench_time(base ^ as.numeric(x))
 
-  scales::trans_new(paste0("bch:tm-", format(base)), transform = trans,
-    inverse = inv, breaks = scales::log_breaks(base = base),
-    domain = c(1e-100, Inf))
+  scales::trans_new(
+    name = paste0("bch:tm-", format(base)),
+    transform = trans,
+    inverse = inv,
+    breaks = scales::log_breaks(base = base),
+    domain = c(1e-100, Inf)
+  )
 }
 
 # Lazily registered in `.onLoad()`


### PR DESCRIPTION
Closes https://github.com/r-lib/bench/pull/144
Closes #143 

The latest release of the scales package has added a pair of optional arguments, `d_transform` and `d_inverse`, in the middle of the parameter list for `trans_new` (see https://github.com/r-lib/scales/pull/341). As a consequence, this has shifted the position of the `breaks` parameter from 4th to 6th.

Because the `bench_time_trans` and `bench_bytes_trans` functions from this package were passing in the breaks object positionally, this change in the scales package means that the breaks object is now matched with the new `d_transform` formal parameter and it ends up being ignored.

This commit changes the arguments to `trans_new` from being positional to being named, which should be more robust to future changes to the function.