### PR TITLE
supply more informative axis breaks in `scale_*_bench_*()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bench (development version)
 
+* `scale_*_bench_*()` functions now supply more informative axis breaks 
+  (@simonpcouch, #143).
+
 # bench 1.1.3
 
 * Long unnamed `bench_expr` expressions are now truncated correctly when used as

--- a/R/bytes.R
+++ b/R/bytes.R
@@ -170,7 +170,7 @@ bench_bytes_trans <- function(base = 2) {
   if (is.null(base)) {
     return(
       scales::trans_new("bch:byt", as.numeric, as_bench_bytes,
-        scales::pretty_breaks(), domain = c(1e-100, Inf)
+        breaks = scales::pretty_breaks(), domain = c(1e-100, Inf)
       )
     )
   }
@@ -178,7 +178,7 @@ bench_bytes_trans <- function(base = 2) {
   inv <- function(x) as_bench_bytes(base ^ as.numeric(x))
 
   scales::trans_new(paste0("bch:byt-", format(base)), trans, inv,
-    scales::log_breaks(base = base), domain = c(1e-100, Inf))
+    breaks = scales::log_breaks(base = base), domain = c(1e-100, Inf))
 }
 
 scale_type.bench_bytes <- function(x) "bench_bytes"

--- a/R/time.R
+++ b/R/time.R
@@ -210,7 +210,7 @@ bench_time_trans <- function(base = 10) {
   if (is.null(base)) {
     return(
       scales::trans_new("bch:tm", as.numeric, as_bench_time,
-        scales::pretty_breaks(), domain = c(1e-100, Inf)
+        breaks = scales::pretty_breaks(), domain = c(1e-100, Inf)
       )
     )
   }
@@ -219,7 +219,7 @@ bench_time_trans <- function(base = 10) {
   inv <- function(x) as_bench_time(base ^ as.numeric(x))
 
   scales::trans_new(paste0("bch:tm-", format(base)), trans, inv,
-    scales::log_breaks(base = base), domain = c(1e-100, Inf))
+    breaks = scales::log_breaks(base = base), domain = c(1e-100, Inf))
 }
 
 scale_type.bench_time <- function(x) "bench_time"


### PR DESCRIPTION
Closes #143. I believe that these breaks functions, passed by position, were intended to be passed to `scales::trans_new(breaks)` rather than `scales::trans_new(d_transform)`.

Here's the reprex from the original issue:

``` r
library(ggplot2)
library(bench)

create_df <- function(rows, cols) {
  as.data.frame(setNames(
    replicate(cols, runif(rows, 1, 1000), simplify = FALSE),
    rep_len(c("x", letters), cols)))
}

# Run 4 data sizes across 3 samples with 2 replicates (24 total benchmarks)
bm <- press(
  rows = c(1000, 10000),
  cols = c(10, 100),
  rep = 1:2,
  {
    dat <- create_df(rows, cols)
    bench::mark(
      min_time = .05,
      bracket = dat[dat$x > 500, ],
      which = dat[which(dat$x > 500), ],
      subset = subset(dat, x > 500)
    )
  }
)
#> Running with:
#>    rows  cols   rep
#> 1  1000    10     1
#> 2 10000    10     1
#> 3  1000   100     1
#> 4 10000   100     1
#> 5  1000    10     2
#> 6 10000    10     2
#> 7  1000   100     2
#> 8 10000   100     2

ggplot(bm) + aes(x = median, y = mem_alloc) + geom_point()
#> Warning: The `trans` argument of `continuous_scale()` is deprecated as of ggplot2 3.5.0.
#> ℹ Please use the `transform` argument instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
```

![](https://i.imgur.com/KEghEzq.png)<!-- -->

<sup>Created on 2024-07-15 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>