### PR TITLE
Simplify skip condition

### DIFF
--- a/tests/testthat/test-mark.R
+++ b/tests/testthat/test-mark.R
@@ -55,7 +55,7 @@ describe("mark", {
   })
 
   it("works with capabilities('profmem')", {
-    skip_if_not(isTRUE(capabilities("profmem")[[1]]))
+    skip_if_not(capabilities("profmem"))
 
     res <- mark(1, 2, check = FALSE, iterations = 1)
 


### PR DESCRIPTION
c.f.

```r
foo = function(nm) c(a=FALSE)[nm]

skip_if_not(isTRUE(foo('a')[[1]]))
# Error: Reason: isTRUE(foo("a")[[1]]) is not TRUE

skip_if_not(foo('a'))
# Error: Reason: foo("a") is not TRUE
```