### PR TITLE
Remove usage of `coord_flip()`

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -49,7 +49,7 @@
 autoplot.bench_mark <- function(object,
   type = c("beeswarm", "jitter", "ridge", "boxplot", "violin"),...) {
 
-  rlang::check_installed(c("ggplot2", "tidyr"), "for `autoplot()`.")
+  rlang::check_installed(c("ggplot2", "tidyr (>= 1.0.0)"), "for `autoplot()`.")
 
   type <- match.arg(type)
 
@@ -62,11 +62,7 @@ autoplot.bench_mark <- function(object,
     object$expression <- as.character(object$expression)
   }
 
-  if (tidyr_new_interface()) {
-    res <- tidyr::unnest(object, c(time, gc))
-  } else {
-    res <- tidyr::unnest(object)
-  }
+  res <- tidyr::unnest(object, c(time, gc))
   p <- ggplot2::ggplot(res)
 
 

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -68,28 +68,25 @@ autoplot.bench_mark <- function(object,
 
   switch(type,
     beeswarm = p <- p +
-      ggplot2::aes(.data$expression, .data$time, color = .data$gc) +
-      ggbeeswarm::geom_quasirandom(...) +
-      ggplot2::coord_flip(),
+      ggplot2::aes(.data$time, .data$expression, color = .data$gc) +
+      ggbeeswarm::geom_quasirandom(..., orientation = "y"),
 
     jitter = p <- p +
-      ggplot2::aes(.data$expression, .data$time, color = .data$gc) +
-      ggplot2::geom_jitter(...) +
-      ggplot2::coord_flip(),
+      ggplot2::aes(.data$time, .data$expression, color = .data$gc) +
+      ggplot2::geom_jitter(...),
 
     ridge = p <- p +
       ggplot2::aes(.data$time, .data$expression) +
       ggridges::geom_density_ridges(...),
 
     boxplot = p <- p +
-      ggplot2::aes(.data$expression, .data$time) +
-      ggplot2::geom_boxplot(...) +
-      ggplot2::coord_flip(),
+      ggplot2::aes(.data$time, .data$expression) +
+      ggplot2::geom_boxplot(...),
 
     violin = p <- p +
-      ggplot2::aes(.data$expression, .data$time) +
-      ggplot2::geom_violin(...) +
-      ggplot2::coord_flip())
+      ggplot2::aes(.data$time, .data$expression) +
+      ggplot2::geom_violin(...)
+  )
 
   parameters <- setdiff(
     colnames(object),

--- a/R/mark.R
+++ b/R/mark.R
@@ -348,11 +348,7 @@ unnest.bench_mark <- function(data, ...) {
 
   # suppressWarnings to avoid 'elements may not preserve their attributes'
   # warnings from dplyr::collapse
-  if (tidyr_new_interface()) {
-    data <- suppressWarnings(NextMethod(.Generic, data, ...))
-  } else {
-    data <- suppressWarnings(NextMethod(.Generic, data, time, gc, .drop = FALSE))
-  }
+  data <- suppressWarnings(NextMethod(.Generic, data, ...))
 
   # Add bench_time class back to the time column
   data$time <- as_bench_time(data$time)

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,11 +86,6 @@ lengths <- function(x, use.names = TRUE) {
   viapply(x, length, USE.NAMES = use.names)
 }
 
-# check if the new interface is being used
-tidyr_new_interface <- function() {
-  utils::packageVersion("tidyr") > "0.8.99"
-}
-
 dots <- function(...) {
   dots <- as.list(substitute(...()))
 

--- a/tests/testthat/test-mark.R
+++ b/tests/testthat/test-mark.R
@@ -226,13 +226,9 @@ describe("summary.bench_mark", {
 
 describe("unnest.bench_mark", {
   it("does not contain result or memory columns", {
-    skip_if_not_installed("tidyr")
+    skip_if_not_installed("tidyr", "1.0.0")
     bnch <- mark(1+1, 2+0)
-    if (tidyr_new_interface()) {
-      res <- tidyr::unnest(bnch, c(time, gc))
-    } else {
-      res <- tidyr::unnest(bnch)
-    }
+    res <- tidyr::unnest(bnch, c(time, gc))
 
     gc_cols <- colnames(bnch$gc[[1]])
 


### PR DESCRIPTION
Since no longer required.

Also require tidyr 1.0.0 (4 years old) (also 1.3.1 in Suggests) part of #127 

`coord_flip()` is superseded in ggplot2 https://ggplot2.tidyverse.org/reference/coord_flip.html?q=coord_fli#null