### PR TITLE
Add `.quiet` argument to `press()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bench (development version)
 
+* `press()` gains a new `.quiet` argument to silence progress messages (#145).
+
 * Fixed an issue in `bench_time_trans()` and `bench_bytes_trans()` where pretty
   breaks were not being applied correctly (#140, @plietar, @simonpcouch).
 

--- a/R/press.R
+++ b/R/press.R
@@ -18,6 +18,7 @@
 #' @param .grid A pre-built grid of values to use, typically a [data.frame] or
 #'   [tibble]. This is useful if you only want to benchmark a subset of all
 #'   possible combinations.
+#' @param .quiet If `TRUE`, progress messages will not be emitted.
 #' @export
 #' @examples
 #' # Helper function to create a simple data.frame of the specified dimensions
@@ -42,8 +43,13 @@
 #'     )
 #'   }
 #' )
-press <- function(..., .grid = NULL) {
+press <- function(..., .grid = NULL, .quiet = FALSE) {
   args <- rlang::quos(...)
+
+  assert(
+    "`.quiet` must be `TRUE` or `FALSE`",
+    isTRUE(.quiet) || isFALSE(.quiet)
+  )
 
   unnamed <- names(args) == ""
 
@@ -70,9 +76,7 @@ press <- function(..., .grid = NULL) {
     )
   }
 
-  quiet <- bench_press_quiet()
-
-  if (!quiet) {
+  if (!.quiet) {
     status <- format(tibble::as_tibble(parameters), n = Inf)
     message(glue::glue("Running with:\n{status[[2]]}"))
   }
@@ -86,7 +90,7 @@ press <- function(..., .grid = NULL) {
       assign(var, value, envir = e)
     }
 
-    if (!quiet) {
+    if (!.quiet) {
       message(status[[row + 3L]])
     }
 
@@ -107,13 +111,4 @@ press <- function(..., .grid = NULL) {
     drop = FALSE
   ]
   bench_mark(tibble::as_tibble(cbind(res[1], parameters, res[-1])))
-}
-
-bench_press_quiet <- function() {
-  # Internal option to silence `press()` during testing
-  isTRUE(getOption("bench.press_quiet", default = FALSE))
-}
-
-local_press_quiet <- function(frame = rlang::caller_env()) {
-  rlang::local_options(bench.press_quiet = TRUE, .frame = frame)
 }

--- a/man/press.Rd
+++ b/man/press.Rd
@@ -4,7 +4,7 @@
 \alias{press}
 \title{Run setup code and benchmarks across a grid of parameters}
 \usage{
-press(..., .grid = NULL)
+press(..., .grid = NULL, .quiet = FALSE)
 }
 \arguments{
 \item{...}{If named, parameters to define, if unnamed the expression to run.
@@ -13,6 +13,8 @@ Only one unnamed expression is permitted.}
 \item{.grid}{A pre-built grid of values to use, typically a \link{data.frame} or
 \link{tibble}. This is useful if you only want to benchmark a subset of all
 possible combinations.}
+
+\item{.quiet}{If \code{TRUE}, progress messages will not be emitted.}
 }
 \description{
 \code{press()} is used to run \code{\link[=mark]{mark()}} across a grid of parameters and

--- a/tests/testthat/test-press.R
+++ b/tests/testthat/test-press.R
@@ -1,17 +1,17 @@
 describe("press", {
   it("Adds parameters to output", {
-    local_press_quiet()
-
     res <- press(
       x = 1,
-      mark(1, max_iterations = 10)
+      mark(1, max_iterations = 10),
+      .quiet = TRUE
     )
     expect_equal(colnames(res), c("expression", "x", summary_cols, data_cols))
     expect_equal(nrow(res), 1)
 
     res2 <- press(
       x = 1:3,
-      mark(1, max_iterations = 10)
+      mark(1, max_iterations = 10),
+      .quiet = TRUE
     )
     expect_equal(colnames(res2), c("expression", "x", summary_cols, data_cols))
     expect_equal(nrow(res2), 3)
@@ -43,12 +43,11 @@ describe("press", {
   })
 
   it("expands the grid if has named parameters", {
-    local_press_quiet()
-
     res <- press(
       x = c(1, 2),
       y = c(1, 3),
-      mark(list(x, y), max_iterations = 10)
+      mark(list(x, y), max_iterations = 10),
+      .quiet = TRUE
     )
 
     expect_equal(res$x, c(1, 2, 1, 2))
@@ -60,11 +59,10 @@ describe("press", {
   })
 
   it("takes values as-is if given in .grid", {
-    local_press_quiet()
-
     res <- press(
       .grid = data.frame(x = c(1, 2), y = c(1, 3)),
-      mark(list(x, y), max_iterations = 10)
+      mark(list(x, y), max_iterations = 10),
+      .quiet = TRUE
     )
 
     expect_equal(res$x, c(1, 2))
@@ -74,15 +72,14 @@ describe("press", {
   })
 
   it("runs `setup` with the parameters evaluated", {
-    local_press_quiet()
-
     x <- 1
     res <- press(
       y = 2,
       {
         x <- y
         mark(x)
-      }
+      },
+      .quiet = TRUE
     )
 
     expect_equal(res$result[[1]], 2)


### PR DESCRIPTION
Revives https://github.com/r-lib/bench/issues/130
Closes https://github.com/r-lib/bench/issues/145